### PR TITLE
Add fs.FS mount option

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -3,6 +3,7 @@ package qjs_test
 import (
 	"path"
 	"testing"
+	"testing/fstest"
 
 	"github.com/fastschema/qjs"
 	"github.com/stretchr/testify/assert"
@@ -376,6 +377,25 @@ func TestModuleLoading(t *testing.T) {
 			},
 		}
 		runEvalTests(t, tests, "./testdata/00_loader")
+	})
+
+	t.Run("FS_Module_Imports", func(t *testing.T) {
+		rt := must(qjs.New(qjs.Option{
+			FS: fstest.MapFS{
+				"math-utils.js": &fstest.MapFile{
+					Data: []byte("export function add(a, b) { return a + b; }"),
+				},
+				"main.js": &fstest.MapFile{
+					Data: []byte("import { add } from 'math-utils.js'; export default String(add(5, 5));"),
+				},
+			},
+		}))
+		defer rt.Close()
+
+		val, err := rt.Eval("main.js", qjs.TypeModule())
+		defer val.Free()
+		assert.NoError(t, err)
+		assert.Equal(t, "10", val.String())
 	})
 }
 

--- a/options.go
+++ b/options.go
@@ -3,6 +3,7 @@ package qjs
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"io"
 	"os"
 )
@@ -32,6 +33,7 @@ const (
 
 type Option struct {
 	CWD               string
+	FS                fs.FS
 	StartFunctionName string
 	Context           context.Context
 	// Enabling this option significantly increases evaluation time

--- a/options_test.go
+++ b/options_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/fastschema/qjs"
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,24 @@ func TestEvalOptions(t *testing.T) {
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "failed to get runtime options")
 		})
+	})
+
+	t.Run("FSOption", func(t *testing.T) {
+		runtime, err := qjs.New(qjs.Option{
+			FS: fstest.MapFS{
+				"main.js": &fstest.MapFile{
+					Data: []byte("export default 'from fs'"),
+				},
+			},
+		})
+		require.NoError(t, err)
+		defer runtime.Close()
+
+		val, err := runtime.Eval("main.js", qjs.TypeModule())
+		require.NoError(t, err)
+		defer val.Free()
+
+		assert.Equal(t, "from fs", val.String())
 	})
 
 	t.Run("CodeOption", func(t *testing.T) {

--- a/runtime.go
+++ b/runtime.go
@@ -132,9 +132,12 @@ func New(options ...Option) (runtime *Runtime, err error) {
 		return nil, fmt.Errorf("failed to setup host module: %w", err)
 	}
 
-	fsConfig := wazero.
-		NewFSConfig().
-		WithDirMount(runtime.option.CWD, "/")
+	fsConfig := wazero.NewFSConfig()
+	if runtime.option.FS != nil {
+		fsConfig = fsConfig.WithFSMount(runtime.option.FS, "/")
+	} else {
+		fsConfig = fsConfig.WithDirMount(runtime.option.CWD, "/")
+	}
 	if runtime.module, err = runtime.wrt.InstantiateModule(
 		option.Context,
 		compiledQJSModule,


### PR DESCRIPTION
## Summary
- add an optional `FS fs.FS` field to `qjs.Option`
- prefer `wazero.FSConfig.WithFSMount(option.FS, "/")` when provided
- preserve the existing `CWD` + `WithDirMount` behavior as the fallback

## Tests
- add `TestEvalOptions/FSOption`
- add `TestModuleLoading/FS_Module_Imports`
- run `go test ./...`

## Why
This makes it possible to execute and import modules from a Go-provided filesystem without requiring a host directory mount, while keeping the current path-based workflow unchanged.